### PR TITLE
MAINT: adds org-wide GHA to add new issues/PRs to QIIME 2 triage board

### DIFF
--- a/.github/workflows/add-to-project-ci.yml
+++ b/.github/workflows/add-to-project-ci.yml
@@ -1,0 +1,21 @@
+name: Add new issues and PRs to QIIME 2 triage project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/qiime2/projects/36
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: skip-triage
+          label-operator: NOT


### PR DESCRIPTION
this uses the same workflow that exists within the QIIME 2 org for adding newly created PRs/issues to the QIIME 2 triage project board. we'll see if this works in a different org (since the github-token might be different) - but i'll test this out once i merge this PR (it won't hurt anything either way - this workflow won't be triggered unless there are any cap lab repos that have the GHA added to them).